### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
   # --- TEST JOB ---
   test:
     name: Run Unit Tests
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/1](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/1)

**General fix:**  
Add an explicit `permissions` block restricting access for the `test` job, so the GITHUB_TOKEN has only the level of access needed (in this case, read-only). This should be set at the job level for `test`, so as not to inadvertently override more permissive but necessary permissions in the `build-deploy` job.

**Detailed fix:**  
Edit the `.github/workflows/deploy.yml` file. Inside the `test` job (directly after line 21, likely after `name: Run Unit Tests`), add a `permissions:` block with `contents: read` as its only entry.

**Requirements:**  
- Insert the block after `name: Run Unit Tests` and before `runs-on: ubuntu-latest`.
- No new dependencies or imports needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
