### PR TITLE
Potential fix for code scanning alert no. 27: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,8 @@
     "nodemailer": "^6.10.0",
     "openai": "^4.90.0",
     "sharp": "^0.34.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "express-rate-limit": "^8.1.0"
   },
   "packageManager": "yarn@4.7.0+sha512.5a0afa1d4c1d844b3447ee3319633797bcd6385d9a44be07993ae52ff4facabccafb4af5dcd1c2f9a94ac113e5e9ff56f6130431905884414229e284e37bb7c9",
   "devDependencies": {


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/27](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/27)

To fix this issue, add a rate-limiting middleware to the `PUT /admin/settings/profile` route. The best approach is to use the widely adopted `express-rate-limit` npm package and apply it to this route only, thereby not altering the functionality of other routes.

Steps:
- Add an import and initialization for `express-rate-limit`.
- Create a rate limiter instance with reasonable settings for admin profile updates (e.g., 5 requests per 15 minutes).
- Attach this rate limiter as middleware to the `PUT /admin/settings/profile` route (before `adminMiddleware` for best effect).
- If this file does not already import or define `express-rate-limit`, add that import at the top.

All changes are to occur in `backend/routes/admin.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
