### PR TITLE
Potential fix for code scanning alert no. 40: Database query built from user-controlled sources

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -197,6 +197,9 @@ router.post('/forgot-password', async (req, res) => {
         if (!email) {
              return res.status(400).json({ message: 'Email is required' });
         }
+        if (typeof email !== 'string') {
+            return res.status(400).json({ message: 'Invalid email format.' });
+        }
         const user = await User.findOne({ email });
 
         // If user not found, send a generic success message to prevent email enumeration.


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/40](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/40)

To prevent NoSQL injection, you should ensure user-supplied `email` is a string before using it in a query. You can either:
1. Explicitly check that `email` is a string and not an object/array (type and plain string).
2. Alternatively, use the MongoDB `$eq` operator to force the comparison to treat the input as a literal value.

The single best way, matching recommendations and the existing validation style, is to add a check for string type:  
- In `router.post('/forgot-password', ...)` in backend/routes/auth.js, immediately after extracting `email`, check that `typeof email === "string"`.  
- If not, return a 400 Bad Request with a suitable error message.

Given the current code checks that `email` exists, the string check can be added immediately after.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
