### PR TITLE
Potential fix for code scanning alert no. 41: Database query built from user-controlled sources

### DIFF
--- a/backend/routes/schedules.js
+++ b/backend/routes/schedules.js
@@ -86,10 +86,16 @@ router.put('/:id', async (req, res) => {
 
         // Destructure only the fields allowed for update from the request body.
         const { title, start, end, type, repeat, repeatType, repeatDays } = req.body;
-        const updateData = { title, start, end, type, repeat, repeatType, repeatDays };
-
-        // Remove any fields from updateData that are undefined to prevent overwriting existing values with null/undefined.
-        Object.keys(updateData).forEach(key => updateData[key] === undefined && delete updateData[key]);
+        // Sanitize and validate update data
+        const updateData = {};
+        if (typeof title === 'string') updateData.title = title;
+        if (typeof start === 'string' || start instanceof Date) updateData.start = start;
+        if (typeof end === 'string' || end instanceof Date) updateData.end = end;
+        if (typeof type === 'string') updateData.type = type;
+        if (typeof repeat === 'boolean') updateData.repeat = repeat;
+        if (typeof repeatType === 'string') updateData.repeatType = repeatType;
+        // repeatDays should be an array of (strings or numbers), but not objects
+        if (Array.isArray(repeatDays) && repeatDays.every(d => typeof d === 'string' || typeof d === 'number')) updateData.repeatDays = repeatDays;
 
         // If no valid update data is provided, return a 400 error.
         if (Object.keys(updateData).length === 0) {


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/41](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/41)

The best way to address this vulnerability is to ensure that user-provided values are treated strictly as literal values when constructing the update object for MongoDB, rather than allowing the possibility of query/update operators appearing in that object. To accomplish this:
- For each field being updated from `req.body`, validate its type and sanitize the value before including it in `updateData`. For example, if a value is expected to be a string, check `typeof value === 'string'`. For primitives, reject objects.
- If stricter type validation is possible (e.g., dates), perform additional checks.
- Optionally, for maximum security, instead of merging all user data, build `updateData` only using fields that pass validation.
- Make these changes directly within the update route handler in backend/routes/schedules.js before passing the update object to Mongoose.
- No external dependencies are needed; rely on built-in JS type checks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
