### PR TITLE
Potential fix for code scanning alert no. 11: Missing rate limiting

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -133,7 +133,7 @@ router.delete('/users/:id', adminMiddleware, async (req, res) => {
 
 // Route to update a user's status (activate/deactivate).
 // PUT /admin/users/:id
-router.put('/users/:id', adminMiddleware, async (req, res) => {
+router.put('/users/:id', profileLimiter, adminMiddleware, async (req, res) => {
     const userId = req.params.id;
     const { isActive: requestedStatus } = req.body; // Get the requested status from the request body.
 


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/11](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/11)

To fix this problem, we must apply a rate limiting middleware to the PUT /admin/users/:id route to mitigate denial-of-service risks from abuse of this expensive (database-writing) endpoint. The existing code already defines a `profileLimiter` middleware (lines 12-18) with sensible settings (max 5 requests per 15 minutes), and this is suitable for sensitive admin actions like this. The fix consists of adding `profileLimiter` to the middleware stack for the PUT /admin/users/:id route on line 136, so that the order of middlewares becomes: `profileLimiter`, `adminMiddleware`, then the async handler. No changes to the limiter itself or new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
