### PR TITLE
Potential fix for code scanning alert no. 39: Database query built from user-controlled sources

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -68,9 +68,12 @@ router.post('/login', async (req, res) => {
         if (!email || !password) {
             return res.status(400).json({ message: 'Email and password are required' });
         }
+        if (typeof email !== 'string') {
+            return res.status(400).json({ message: 'Invalid email format' });
+        }
 
         // Find the user by email.
-        const user = await User.findOne({ email });
+        const user = await User.findOne({ email: { $eq: email } });
         if (!user) {
             return res.status(400).json({ message: 'Invalid credentials' });
         }


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/39](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/39)

To fix the problem, we need to ensure that untrusted input (`email`) is always treated as a string value in the query. This is commonly done in two ways:

1. By verifying that the value is a string (and optionally, also validating email format using a regex or a validator library).
2. By using MongoDB's `$eq` operator (i.e., `{ email: { $eq: email } }`), which ensures the email is only compared as a value.

The simplest robust fix, compatible with the code as written and requiring minimal changes, is to check that `email` is a string before running the query. If it's not, return a Bad Request error. This fix can be implemented before the query on line 73 in `backend/routes/auth.js`.

Optionally, for extra safety, you could combine both approaches (validate type and use `$eq`), but either is sufficient per the best-practice recommendations.

**What needs to be changed:**
- Before running `User.findOne({ email })`, add a check: if `typeof email !== 'string'`, return an error response.
- Optionally, could also use `{ email: { $eq: email } }` instead of `{ email }` in the query.

No new dependencies are needed for simple type checking.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
