### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -26,6 +26,15 @@ const deleteUserLimiter = rateLimit({
     legacyHeaders: false,
 });
 
+// Set up a rate limiter for the dashboard statistics route.
+const dashboardLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes window
+    max: 10, // limit each admin to 10 dashboard requests per windowMs
+    message: { message: 'Too many dashboard requests, please try again later.' },
+    standardHeaders: true,
+    legacyHeaders: false,
+});
+
 // Helper function for logging recent activities.
 const logActivity = async (type, details, userId, adminUserId = null, petId = null, scheduleId = null) => {
     try {
@@ -62,7 +71,7 @@ router.get('/user', adminMiddleware, async (req, res) => {
 
 // Route to get dashboard statistics for the admin panel.
 // GET /admin/dashboard
-router.get('/dashboard', adminMiddleware, async (req, res) => {
+router.get('/dashboard', dashboardLimiter, adminMiddleware, async (req, res) => {
     try {
         const totalUsers = await User.countDocuments();
         const totalPets = await Pet.countDocuments();


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/4](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/4)

To address the missing rate limiting on the `/admin/dashboard` endpoint, we should apply a reasonable rate limiter to it, using the already-imported `express-rate-limit` package. The fix is to create a new rate limiter instance tailored for dashboard statistics—allowing a modest number of requests per admin per window (e.g., 10 requests per 15 minutes)—and apply it to the dashboard route by adding it to the list of middlewares, e.g. as `router.get('/dashboard', dashboardLimiter, adminMiddleware, ...)`. This can be done entirely within the existing code region, using conventions seen for other limiters (such as `profileLimiter` and `deleteUserLimiter`). Implementation requires defining the new limiter and attaching it to the endpoint.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
