### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -99,7 +99,7 @@ router.get('/dashboard', dashboardLimiter, adminMiddleware, async (req, res) => 
 
 // Route to get a list of all users in the system.
 // GET /admin/users
-router.get('/users', adminMiddleware, async (req, res) => {
+router.get('/users', dashboardLimiter, adminMiddleware, async (req, res) => {
     try {
         const users = await User.find().select('-password'); // Exclude password from the response
         res.json(users);


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/6](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/6)

To fix this problem, we should apply a suitable rate-limiting middleware to the route `GET /admin/users`, just as is already done for other sensitive admin endpoints (e.g., `profileLimiter`, `dashboardLimiter`). The nature of this endpoint (listing all users) is database intensive and could be abused, so a reasonable limit should be used, such as 10 requests per 15 minutes per admin user, as with `dashboardLimiter`. 

The cleanest solution is to reuse the existing `dashboardLimiter` unless a different policy is desired.  
**Steps:**  
- In `backend/routes/admin.js`, update the `.get('/users', ...)` route handler to include `dashboardLimiter` as a middleware argument (added before `adminMiddleware`, or just after, to mirror other routes).
- No external dependencies or new variable declarations are required as `dashboardLimiter` is already imported and configured.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
