### PR TITLE
Potential fix for code scanning alert no. 31: Missing rate limiting

### DIFF
--- a/backend/routes/schedules.js
+++ b/backend/routes/schedules.js
@@ -76,7 +76,7 @@ router.post('/add', async (req, res) => {
 
 // Route to update an existing schedule by its ID.
 // PUT /schedules/:id
-router.put('/:id', async (req, res) => {
+router.put('/:id', updateScheduleLimiter, async (req, res) => {
     try {
         const scheduleId = req.params.id;
         // Validate that the scheduleId is a valid MongoDB ObjectId format.


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/31](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/31)

To fix this security vulnerability, a rate-limiting middleware should be applied to the `PUT /schedules/:id` route handler. The fix should follow the pattern used for the DELETE handler if possible (which appears to use a rate limiter middleware named `deleteScheduleLimiter`). We can create a new middleware for the update route (e.g., `updateScheduleLimiter`), using the `express-rate-limit` package, configuring the rate limit as appropriate (perhaps similar to delete: e.g., 5 requests per minute as a baseline, unless stricter or looser limits are preferred). This middleware should be inserted as the second argument to the `.put` route (as with the `.delete` route), and the definition for the limiter itself should be present above the route definitions.

**Steps:**
- Define a new rate limiter (e.g., `updateScheduleLimiter`) before the routes.
- Apply the limiter by inserting it as the second argument to `router.put('/:id', ...)`.

**Required changes:**
- Add the creation of the rate limiter above the route definitions (after requires but before the router).
- Edit the `router.put('/:id'...)` line to include the limiter as middleware.
- Ensure the relevant import for `express-rate-limit` is present (already imported as `rateLimit`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
