### PR TITLE
Potential fix for code scanning alert no. 30: Missing rate limiting

### DIFF
--- a/backend/routes/schedules.js
+++ b/backend/routes/schedules.js
@@ -1,12 +1,17 @@
 const express = require('express');
 const rateLimit = require('express-rate-limit');
+const getSchedulesByOwnerLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    message: { message: "Too many requests for schedules by owner. Please try again later." }
+});
 const router = express.Router();
 const Schedule = require('../models/Schedule');
 const User = require('../models/User');
 const RecentActivity = require('../models/RecentActivity');
 const mongoose = require('mongoose'); // Import mongoose to check ObjectId validity
 // GET /schedules/owner/:ownerId
-router.get('/owner/:ownerId', async (req, res) => {
+router.get('/owner/:ownerId', getSchedulesByOwnerLimiter, async (req, res) => {
     try {
         const ownerId = req.params.ownerId;
         // Validate that the ownerId is a valid MongoDB ObjectId format.


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/30](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/30)

To address the missing rate limiting, we should apply a rate limiting middleware to the affected route. Since `express-rate-limit` is already imported as `rateLimit` (line 2), we can locally instantiate a rate limiter for this route (or share with others as appropriate). The best fix is to define a dedicated rate limiter (e.g., allowing a reasonable number of requests per time window, say 100 per 15 minutes) and apply it to the `/owner/:ownerId` `GET` endpoint either inline or as a named middleware. This involves:

- Defining a new rateLimiter (e.g., `getSchedulesByOwnerLimiter`) in `backend/routes/schedules.js`.
- Applying it as the first argument to the `.get('/owner/:ownerId', ...)` route definition.
- The fix is local to `backend/routes/schedules.js`.
- No changes to functionality or route logic are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
