### PR TITLE
Potential fix for code scanning alert no. 20: Missing rate limiting

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -136,7 +136,7 @@ router.get('/user', userDetailLimiter, userMiddleware, async (req, res) => {
 // Route for a user to update their own password.
 // PUT /auth/settings/password
 // Protected by userMiddleware.
-router.put('/settings/password', userMiddleware, async (req, res) => {
+router.put('/settings/password', passwordChangeLimiter, userMiddleware, async (req, res) => {
     try {
         const { currentPassword, newPassword } = req.body;
         const user = await User.findById(req.user.id);


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/20](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/20)

To remediate this issue, a rate limiter middleware should be added to the `/auth/settings/password` route. The best practice is to use the existing `express-rate-limit` package, already imported as `rateLimit` in this file, and define a limiter tailored for sensitive endpoints like password changes.

Steps:
- Define a new rate limiter instance (e.g., `passwordChangeLimiter`) near the other limiter declarations. For a password change endpoint, a stricter limit (e.g., 5 requests per hour per user/IP) is reasonable.
- Apply this middleware to the corresponding route: `router.put('/settings/password', passwordChangeLimiter, userMiddleware, ...)`.
- Ensure the limiter is positioned before the authentication middleware so rate-limiting is enforced regardless of authorization outcome, or after if you want to limit per authenticated user (if the limiter is configured to use a key based on the authenticated user ID, otherwise default is per IP).

Edits are only to be made in `backend/routes/auth.js`, adding (1) the limiter definition, and (2) the middleware to the route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
