### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -30,10 +30,18 @@ const userDetailLimiter = rateLimit({
     standardHeaders: true,
     legacyHeaders: false,
 });
+// Rate limiter for signup route: max 5 requests per 15 minutes per IP.
+const signupLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 5,
+    message: { message: 'Too many signup attempts. Please try again later.' },
+    standardHeaders: true,
+    legacyHeaders: false,
+});
 const router = express.Router();
 // Route for user registration.
 // POST /auth/signup
-router.post('/signup', async (req, res) => {
+router.post('/signup', signupLimiter, async (req, res) => {
     try {
         const { email, password, username, age } = req.body;
 


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/8](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/8)

To fix the problem, the `/signup` route handler should be protected by a rate limiter middleware, just like the profile update and user info routes. This can be accomplished by creating a new `express-rate-limit` instance specifically configured for the `/signup` endpoint, or by reusing an existing (if the limit is appropriate). For this registration endpoint, a restrictive limit (e.g., 5 attempts per IP per 15 minutes) is common to prevent replay and stop account creation abuse while not overly inconveniencing genuine users.

**Best approach:**  
- Define a new rate limiter for `/signup`, e.g., `signupLimiter`—preferably in the same style as the other route-specific limiters already in this file.
- Apply `signupLimiter` as middleware for the signup handler, i.e., `router.post('/signup', signupLimiter, async (req, res) => {...})`.
- The definition of `signupLimiter` should be added above the router declaration and below the `require` calls and current limiter definitions for clarity and maintainability.

**Required elements:**  
- One new `express-rate-limit` definition for signup with restrictively low threshold.
- Middleware hook into the signup POST route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
