### PR TITLE
Potential fix for code scanning alert no. 13: Missing rate limiting

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -38,6 +38,14 @@ const signupLimiter = rateLimit({
     standardHeaders: true,
     legacyHeaders: false,
 });
+// Rate limiter for login route: max 10 requests per 15 minutes per IP.
+const loginLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 10,
+    message: { message: 'Too many login attempts. Please try again later.' },
+    standardHeaders: true,
+    legacyHeaders: false,
+});
 const router = express.Router();
 // Route for user registration.
 // POST /auth/signup
@@ -85,7 +93,7 @@ router.post('/signup', signupLimiter, async (req, res) => {
 
 // Route for user login.
 // POST /auth/login
-router.post('/login', async (req, res) => {
+router.post('/login', loginLimiter, async (req, res) => {
     try {
         const { email, password } = req.body;
         // Validate input.


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/13](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/13)

The best way to fix this problem is to add a rate limiting middleware to the `/auth/login` route, just as is already being done for `/auth/signup` and `/auth/user`. This is done by defining a limiter using `express-rate-limit` and then applying it as middleware. A reasonable configuration would set a low maximum (e.g., 5-10 attempts per 15 minutes) to mitigate brute-force (credential stuffing) attacks on login. The new limiter should be defined near the other rate limiters at the top of the file, and then referenced in the middleware array for the login POST route.

**Changes:**
- Define a `loginLimiter` before the router is initialized.
- Apply `loginLimiter` as middleware to the POST `/auth/login` route (on line 88).
- This does not require new imports, as `express-rate-limit` is already imported as `rateLimit`.
- The limiter configuration should closely follow the styles and patterns used for `signupLimiter`, with appropriate modifications to its name, comment, and error message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
