### PR TITLE
Potential fix for code scanning alert no. 32: Missing rate limiting

### DIFF
--- a/backend/routes/pets.js
+++ b/backend/routes/pets.js
@@ -12,6 +12,13 @@ const { uploadFileToS3, deleteFileFromS3 } = require('../utils/s3Utils');
 const rateLimit = require('express-rate-limit');
 // Limit to 100 requests per 15 minutes per IP for "get all pets" endpoint
 
+// Limit to 100 requests per 15 minutes per IP for "get pets by owner" endpoint
+const getPetsByOwnerLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: 'Too many requests for pets by owner, please try again later.',
+});
+
 // Rate limiter for deleting pets: max 10 deletes per 15 minutes per IP
 const deletePetLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
@@ -184,7 +191,7 @@ router.post('/add', (req, res, next) => {
 
 // Route to get all pets belonging to a specific owner.
 // GET /pets/owner/:ownerId
-router.get('/owner/:ownerId', async (req, res) => {
+router.get('/owner/:ownerId', getPetsByOwnerLimiter, async (req, res) => {
     try {
         const ownerId = req.params.ownerId;
         // Validate the ownerId format.


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/32](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/32)

To fix this problem, we should add `express-rate-limit` middleware to the `/pets/owner/:ownerId` route. It's best to do this with a named rate limiter definition to allow adjustment and clarity, in the same style as the `getAllPetsLimiter` already used for the `/pets/` route. The rate limiter can be defined near the top of the file, e.g. with a reasonable default such as 100 requests per 15 minutes per IP. Then, we add it as middleware to the `router.get('/owner/:ownerId', ...)` route, so requests to this endpoint are rate-limited and can't overwhelm the database.

**Steps:**
1. Define a rate limiter (e.g. `getPetsByOwnerLimiter`) near the top of the file, like `getAllPetsLimiter`.
2. Attach `getPetsByOwnerLimiter` as a middleware to the route handler for `GET /pets/owner/:ownerId`.

No changes to functionality, only middleware attachment for rate limiting.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
