### PR TITLE
Potential fix for code scanning alert no. 28: Missing rate limiting

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -226,7 +226,7 @@ router.put('/settings/profile', userMiddleware, profileUpdateLimiter, async (req
 
 // Route to initiate the password reset process.
 // POST /auth/forgot-password
-router.post('/forgot-password', async (req, res) => {
+router.post('/forgot-password', forgotPasswordLimiter, async (req, res) => {
     try {
         const { email } = req.body;
         if (!email) {
@@ -261,6 +261,12 @@ router.post('/forgot-password', async (req, res) => {
     }
 });
 
+// Rate limiter for forgot-password endpoint: limits requests to prevent abuse.
+const forgotPasswordLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour window
+  max: 5, // start blocking after 5 requests
+  message: "Too many password reset requests from this IP, please try again after an hour."
+});
 // Route to reset the password using a valid token.
 // POST /auth/reset-password/:token
 router.post('/reset-password/:token', resetPasswordLimiter, async (req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/28](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/28)

To fix the issue, you should apply rate limiting middleware to the `/forgot-password` route, similarly to how rate limiting is applied to other sensitive routes (`reset-password`, `settings/password`, etc.).

The fix involves:
- Defining a rate limiter instance (using `express-rate-limit`) for the `/forgot-password` endpoint. The rate limit for this route should be fairly strict (e.g., maximum 5 requests per hour per IP is common for forgot-password functionality).
- Applying this limiter as middleware for the `/forgot-password` route.
- This requires inserting the limiter definition in the file (near other limiters if they exist) and attaching it to the route as an argument before the handler.

No changes to existing business logic are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
