### PR TITLE
Potential fix for code scanning alert no. 35: Missing rate limiting

### DIFF
--- a/backend/routes/schedules.js
+++ b/backend/routes/schedules.js
@@ -5,6 +5,13 @@ const getSchedulesByOwnerLimiter = rateLimit({
     max: 100, // limit each IP to 100 requests per windowMs
     message: { message: "Too many requests for schedules by owner. Please try again later." }
 });
+
+// Rate limiter for adding an exception to a schedule
+const addExceptionLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    message: { message: "Too many requests for adding schedule exceptions. Please try again later." }
+});
 const router = express.Router();
 const Schedule = require('../models/Schedule');
 const User = require('../models/User');
@@ -166,7 +173,7 @@ router.delete('/:id', deleteScheduleLimiter, async (req, res) => {
 // Route to add an exception date to a repeating schedule rule.
 // This marks a specific occurrence of a repeating event as skipped.
 // POST /schedules/:id/exception
-router.post('/:id/exception', async (req, res) => {
+router.post('/:id/exception', addExceptionLimiter, async (req, res) => {
     try {
         const ruleId = req.params.id; // The ID of the schedule rule.
         // Validate that the ruleId is a valid MongoDB ObjectId format.


### PR DESCRIPTION
Potential fix for [https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/35](https://github.com/Anasmtaweh/pet-ai-project/security/code-scanning/35)

To fix the problem, we need to add rate-limiting middleware to the affected route (`POST /schedules/:id/exception`) to prevent potential abuse via excessive requests. The best fix is to define a new rate limiter specifically for this route (named e.g. `addExceptionLimiter`), in analogous fashion to the other named limiters already present. The rate limit parameters should match others for consistency (e.g., 100 requests per 15 minutes per IP, with an appropriate message). 

Changes required:
- At the top of the file, define a new instance of a rate limiter (`addExceptionLimiter`) using `rateLimit`.
- Apply this middleware to the relevant route by including it as an argument in the router line (i.e., changing `router.post('/:id/exception', async ...` to `router.post('/:id/exception', addExceptionLimiter, async ...`).

No other functionality needs modification, and this maintains existing behavior for legitimate users.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
